### PR TITLE
SIMD-ification

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/sdsl-lite"]
 	path = external/sdsl-lite
 	url = https://github.com/xxsds/sdsl-lite.git
+[submodule "simde"]
+	path = simde
+	url = https://github.com/simd-everywhere/simde.git

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,18 +1,19 @@
 CWD = $(shell pwd)
 INCDIR = $(CWD)/..
 SDSLDIR = $(CWD)/../external/sdsl-lite/include/
+SIMDEDIR = $(CWD)/../simde/
 CXX ?= g++
-CPPFLAGS = -std=c++14 -m64 -g -O3 -I$(INCDIR) -I$(SDSLDIR)
+CPPFLAGS = -std=c++14 -m64 -g -O3 -I$(INCDIR) -I$(SDSLDIR) -I$(SIMDEDIR)
 
 
 all: test benchmark
 
-.PHONY: clean $(INCDIR)/wfalm.hpp $(INCDIR)/wfalm_st.hpp
+.PHONY: clean
 
-test: test.cpp $(INCDIR)/wfalm.hpp $(INCDIR)/wfalm_st.hpp
+test: test.cpp $(INCDIR)/wfa_lm.hpp $(INCDIR)/wfa_lm_st.hpp
 	$(CXX) $(CPPFLAGS) test.cpp -o test
 
-benchmark: benchmark.cpp
+benchmark: benchmark.cpp $(INCDIR)/wfa_lm.hpp $(INCDIR)/wfa_lm_st.hpp
 	$(CXX) $(CPPFLAGS) benchmark.cpp -o benchmark
 
 clean:

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv) {
     //  TACGG-CACGGCGATGAACGACGGCACTTTCTCCA--TTGTCC
     //                   ^2 placements for this
     // 0     1   1    2  3        5  5     67     8
-    // 0     1   9    9  4        2  8     90     2
+    //       1   9    9  4        2  8     90     2
     //      1   1    2  3        5  5     66     88
     //      0   7    7  3        0  6     89     02
     std::string seq1 = "TACGGTCACCGCGACGACGACGGCAATTACTCCAAGTTGTCT";

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -66,11 +66,15 @@ int score_cigar(const std::string& seq1, const std::string& seq2,
 
 int main(int argc, char** argv) {
     
-    // 0    2   3   4  6         7  8     11     12
-    //          *   *            *  *            *
-    // TACGGTCACCGCGACG-ACGACGGCAATTACTCCAAGTTGTCT
-    // TACGG-CACGGCGATGAACGACGGCACTTTCTCCA--TTGTCC
-    //                 ^2 placements for this
+    //  0    2   3    4  6        7  8     11     12
+    //           *    *           *  *            *
+    //  TACGGTCACCGCGACGA-CGACGGCAATTACTCCAAGTTGTCT
+    //  TACGG-CACGGCGATGAACGACGGCACTTTCTCCA--TTGTCC
+    //                   ^2 placements for this
+    // 0     1   1    2  3        5  5     67     8
+    // 0     1   9    9  4        2  8     90     2
+    //      1   1    2  3        5  5     66     88
+    //      0   7    7  3        0  6     89     02
     std::string seq1 = "TACGGTCACCGCGACGACGACGGCAATTACTCCAAGTTGTCT";
     std::string seq2 = "TACGGCACGGCGATGAACGACGGCACTTTCTCCATTGTCC";
     
@@ -78,7 +82,7 @@ int main(int argc, char** argv) {
     int gap_open = 1;
     int gap_extend = 1;
     int max_mem = 400;
-    std::cerr << "making aligner" << std::endl;
+
     wfalm::WFAligner aligner(mismatch, gap_open, gap_extend);
     wfalm::WFAlignerST aligner_st(mismatch, gap_open, gap_extend);
     


### PR DESCRIPTION
This includes a pretty extensive refactor that uses explicit SIMD instructions from SSE to accelerate the `next` and `extend` functions. Also adds a `simde` submodule for portability.