### PR TITLE
Implementation of piecewise affine gap penalties

### DIFF
--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -156,10 +156,10 @@ int64_t max_memory_usage() {
 
 int main(int argc, char **argv) {
     
-    int match = default_match;
-    int mismatch = default_mismatch;
-    int gap_open = default_gap_open;
-    int gap_extend = default_gap_extend;
+    uint32_t match = default_match;
+    uint32_t mismatch = default_mismatch;
+    uint32_t gap_open = default_gap_open;
+    uint32_t gap_extend = default_gap_extend;
     size_t anchor11 = 0, anchor12 = 0, anchor21 = 0, anchor22 = 0;
     bool local = false;
     bool compare_match = true;
@@ -302,12 +302,12 @@ int main(int argc, char **argv) {
     WFAligner<1> aligner;
     WFAlignerST<1> aligner_st;
     if (match == 0) {
-        aligner = WFAligner<1>(mismatch, gap_open, gap_extend);
-        aligner_st = WFAlignerST<1>(mismatch, gap_open, gap_extend);
+        aligner = WFAligner<1>(mismatch, {gap_extend}, {gap_open});
+        aligner_st = WFAlignerST<1>(mismatch, {gap_extend}, {gap_open});
     }
     else {
-        aligner = WFAligner<1>(match, mismatch, gap_open, gap_extend);
-        aligner_st = WFAlignerST<1>(match, mismatch, gap_open, gap_extend);
+        aligner = WFAligner<1>(match, mismatch, {gap_extend}, {gap_open});
+        aligner_st = WFAlignerST<1>(match, mismatch, {gap_extend}, {gap_open});
     }
     
     cerr << "[progress] aligning sequences '" << seqname1 << "' (length " << seq1.size() << ") and '" << seqname2 << "' (length " << seq2.size() << "):" << endl;

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -299,15 +299,15 @@ int main(int argc, char **argv) {
     cerr << "PARSE TIME: " << parse_time.count() << " us" << endl;
     cerr << "BASELINE MEM: " << max_memory_usage() << " KB" << endl;
 
-    WFAligner aligner;
-    WFAlignerST aligner_st;
+    WFAligner<1> aligner;
+    WFAlignerST<1> aligner_st;
     if (match == 0) {
-        aligner = WFAligner(mismatch, gap_open, gap_extend);
-        aligner_st = WFAlignerST(mismatch, gap_open, gap_extend);
+        aligner = WFAligner<1>(mismatch, gap_open, gap_extend);
+        aligner_st = WFAlignerST<1>(mismatch, gap_open, gap_extend);
     }
     else {
-        aligner = WFAligner(match, mismatch, gap_open, gap_extend);
-        aligner_st = WFAlignerST(match, mismatch, gap_open, gap_extend);
+        aligner = WFAligner<1>(match, mismatch, gap_open, gap_extend);
+        aligner_st = WFAlignerST<1>(match, mismatch, gap_open, gap_extend);
     }
     
     cerr << "[progress] aligning sequences '" << seqname1 << "' (length " << seq1.size() << ") and '" << seqname2 << "' (length " << seq2.size() << "):" << endl;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -83,8 +83,8 @@ int main(int argc, char** argv) {
     int gap_extend = 1;
     int max_mem = 400;
 
-    wfalm::WFAligner aligner(mismatch, gap_open, gap_extend);
-    wfalm::WFAlignerST aligner_st(mismatch, gap_open, gap_extend);
+    wfalm::WFAligner<1> aligner(mismatch, gap_open, gap_extend);
+    wfalm::WFAlignerST<1> aligner_st(mismatch, gap_open, gap_extend);
     
     int prune = -1;//ceil(-2.0 * log(1e-12) / log(4.0));
     aligner.lagging_diagonal_prune = prune;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -178,8 +178,8 @@ int main(int argc, char** argv) {
     int gap_extend_sw = 1;
     int max_mem_sw = 200;
     
-    wfalm::WFAligner aligner_sw(match_sw, mismatch_sw, gap_open_sw, gap_extend_sw);
-    wfalm::WFAlignerST aligner_sw_st(match_sw, mismatch_sw, gap_open_sw, gap_extend_sw);
+    wfalm::WFAligner<1> aligner_sw(match_sw, mismatch_sw, gap_open_sw, gap_extend_sw);
+    wfalm::WFAlignerST<1> aligner_sw_st(match_sw, mismatch_sw, gap_open_sw, gap_extend_sw);
     
     int anchor_begin_1 = pref1.size() + 16;
     int anchor_end_1 = pref1.size() + 25;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -78,13 +78,13 @@ int main(int argc, char** argv) {
     std::string seq1 = "TACGGTCACCGCGACGACGACGGCAATTACTCCAAGTTGTCT";
     std::string seq2 = "TACGGCACGGCGATGAACGACGGCACTTTCTCCATTGTCC";
     
-    int mismatch = 1;
-    int gap_open = 1;
-    int gap_extend = 1;
-    int max_mem = 400;
+    uint32_t mismatch = 1;
+    uint32_t gap_open = 1;
+    uint32_t gap_extend = 1;
+    uint32_t max_mem = 400;
 
-    wfalm::WFAligner<1> aligner(mismatch, gap_open, gap_extend);
-    wfalm::WFAlignerST<1> aligner_st(mismatch, gap_open, gap_extend);
+    wfalm::WFAligner<1> aligner(mismatch, {gap_extend}, {gap_open});
+    wfalm::WFAlignerST<1> aligner_st(mismatch, {gap_extend}, {gap_open});
     
     int prune = -1;//ceil(-2.0 * log(1e-12) / log(4.0));
     aligner.lagging_diagonal_prune = prune;
@@ -172,14 +172,14 @@ int main(int argc, char** argv) {
     auto local_seq1 = pref1 + seq1 + suff1;
     auto local_seq2 = pref2 + seq2 + suff2;
     
-    int match_sw = 1;
-    int mismatch_sw = 1;
-    int gap_open_sw = 2;
-    int gap_extend_sw = 1;
+    uint32_t match_sw = 1;
+    uint32_t mismatch_sw = 1;
+    uint32_t gap_open_sw = 2;
+    uint32_t gap_extend_sw = 1;
     int max_mem_sw = 200;
     
-    wfalm::WFAligner<1> aligner_sw(match_sw, mismatch_sw, gap_open_sw, gap_extend_sw);
-    wfalm::WFAlignerST<1> aligner_sw_st(match_sw, mismatch_sw, gap_open_sw, gap_extend_sw);
+    wfalm::WFAligner<1> aligner_sw(match_sw, mismatch_sw, {gap_extend_sw}, {gap_open_sw});
+    wfalm::WFAlignerST<1> aligner_sw_st(match_sw, mismatch_sw, {gap_extend_sw}, {gap_open_sw});
     
     int anchor_begin_1 = pref1.size() + 16;
     int anchor_end_1 = pref1.size() + 25;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -30,22 +30,50 @@
 #include "wfa_lm.hpp"
 #include "wfa_lm_st.hpp"
 
+
+template<int N>
 int score_cigar(const std::string& seq1, const std::string& seq2,
                 const std::vector<wfalm::CIGAROp>& cigar,
-                int mismatch, int gap_open, int gap_extend) {
+                int mismatch, std::array<uint32_t, N> gap_open, std::array<uint32_t, std::max(1, N)> gap_extend) {
     int s = 0;
     int i = 0;
     int j = 0;
     for (auto c : cigar) {
         switch (c.op) {
             case 'I':
+            {
+                int min_penalty = 100000000;
+                for (size_t k = 0; k < gap_extend.size(); ++k) {
+                    int penalty;
+                    if (k < gap_open.size()) {
+                        penalty = gap_open[k] + c.len * gap_extend[k];
+                    }
+                    else {
+                        penalty = c.len * gap_extend[k];
+                    }
+                    min_penalty = std::min(min_penalty, penalty);
+                }
                 i += c.len;
-                s += gap_open + c.len * gap_extend;
+                s += min_penalty;
                 break;
+            }
             case 'D':
+            {
+                int min_penalty = 100000000;
+                for (size_t k = 0; k < gap_extend.size(); ++k) {
+                    int penalty;
+                    if (k < gap_open.size()) {
+                        penalty = gap_open[k] + c.len * gap_extend[k];
+                    }
+                    else {
+                        penalty = c.len * gap_extend[k];
+                    }
+                    min_penalty = std::min(min_penalty, penalty);
+                }
                 j += c.len;
-                s += gap_open + c.len * gap_extend;
+                s += min_penalty;
                 break;
+            }
             case 'M':
             {
                 for (int k = 0; k < c.len; ++k, ++i, ++j) {
@@ -66,6 +94,7 @@ int score_cigar(const std::string& seq1, const std::string& seq2,
 
 int main(int argc, char** argv) {
     
+    // anchor            |       |
     //  0    2   3    4  6        7  8     11     12
     //           *    *           *  *            *
     //  TACGGTCACCGCGACGA-CGACGGCAATTACTCCAAGTTGTCT
@@ -77,14 +106,29 @@ int main(int argc, char** argv) {
     //      0   7    7  3        0  6     89     02
     std::string seq1 = "TACGGTCACCGCGACGACGACGGCAATTACTCCAAGTTGTCT";
     std::string seq2 = "TACGGCACGGCGATGAACGACGGCACTTTCTCCATTGTCC";
+
+//    uint32_t mismatch = 1;
+//    std::array<uint32_t, 0> gap_open;
+//    std::array<uint32_t, 1> gap_extend{1};
+//    uint32_t max_mem = 400;
     
     uint32_t mismatch = 1;
-    uint32_t gap_open = 1;
-    uint32_t gap_extend = 1;
+    std::array<uint32_t, 1> gap_open{1};
+    std::array<uint32_t, 1> gap_extend{1};
     uint32_t max_mem = 400;
 
-    wfalm::WFAligner<1> aligner(mismatch, {gap_extend}, {gap_open});
-    wfalm::WFAlignerST<1> aligner_st(mismatch, {gap_extend}, {gap_open});
+//    // TACGGC-CGGCGATG--------CACTTTCTCCATTG-CC
+//    // TACGGCACGGCGATGAACGACGGCACTTTCTCCATTGTCC
+//    std::string seq1 = "TACGGCCGGCGATGCACTTTCTCCATTGCC";
+//    std::string seq2 = "TACGGCACGGCGATGAACGACGGCACTTTCTCCATTGTCC";
+//
+//    uint32_t mismatch = 1;
+//    std::array<uint32_t, 2> gap_open{1, 3};
+//    std::array<uint32_t, 2> gap_extend{2, 1};
+//    uint32_t max_mem = 400;
+
+    wfalm::WFAligner<1> aligner(mismatch, gap_extend, gap_open);
+    wfalm::WFAlignerST<1> aligner_st(mismatch, gap_extend, gap_open);
     
     int prune = -1;//ceil(-2.0 * log(1e-12) / log(4.0));
     aligner.lagging_diagonal_prune = prune;
@@ -97,8 +141,16 @@ int main(int argc, char** argv) {
     std::cout << seq2 << std::endl;
     std::cout << "params:" << std::endl;
     std::cout << "\tx = " << mismatch << std::endl;
-    std::cout << "\to = " << gap_open << std::endl;
-    std::cout << "\te = " << gap_extend << std::endl;
+    std::cout << "\to =";
+    for (auto o : gap_open) {
+        std::cout << ' ' << o;
+    }
+    std::cout << std::endl;
+    std::cout << "\te =";
+    for (auto e : gap_extend) {
+        std::cout << ' ' << e;
+    }
+    std::cout << std::endl;
     std::cout << "\tp = " << prune << std::endl;
     std::cout << "\tM = " << max_mem << std::endl;
     for (int mem : {0, 1, 2, 3}) {
@@ -151,8 +203,7 @@ int main(int argc, char** argv) {
 
             }
             auto cigar = res.first;
-            int s = score_cigar(seq1, seq2, cigar, mismatch, gap_open, gap_extend);
-            assert(s == res.second);
+            int s = res.second;
 
             std::cout << "score: " << s << std::endl;
             std::cout << "score density: " << double(s) / double(seq1.size() + seq2.size()) << std::endl;
@@ -161,6 +212,8 @@ int main(int argc, char** argv) {
                 std::cout << cigar_op.len << cigar_op.op;
             }
             std::cout << std::endl;
+            
+            assert(s == score_cigar<1>(seq1, seq2, cigar, mismatch, gap_open, gap_extend));
         }
     }
     
@@ -168,26 +221,26 @@ int main(int argc, char** argv) {
     std::string pref2 = "ACCCGGCTCACGCC";
     std::string suff1 = "GAGAACTCTAATGG";
     std::string suff2 = "CTTTTAAATGGTAG";
-    
+
     auto local_seq1 = pref1 + seq1 + suff1;
     auto local_seq2 = pref2 + seq2 + suff2;
-    
+
     uint32_t match_sw = 1;
     uint32_t mismatch_sw = 1;
     uint32_t gap_open_sw = 2;
     uint32_t gap_extend_sw = 1;
     int max_mem_sw = 200;
-    
+
     wfalm::WFAligner<1> aligner_sw(match_sw, mismatch_sw, {gap_extend_sw}, {gap_open_sw});
     wfalm::WFAlignerST<1> aligner_sw_st(match_sw, mismatch_sw, {gap_extend_sw}, {gap_open_sw});
-    
+
     int anchor_begin_1 = pref1.size() + 16;
     int anchor_end_1 = pref1.size() + 25;
     int anchor_begin_2 = pref2.size() + 16;
     int anchor_end_2 = pref2.size() + 25;
-    
+
     std::cout << std::endl << "LOCAL ALIGNMENT" << std::endl;
-    
+
     std::cout << "sequence 1: " << std::endl;
     std::cout << local_seq1 << std::endl;
     std::cout << "sequence 2: " << std::endl;
@@ -271,7 +324,7 @@ int main(int argc, char** argv) {
                                                        false);
             }
             auto cigar = std::get<0>(res);
-            
+
             std::cout << "score: " << std::get<1>(res) << std::endl;
             std::cout << "aligned intervals: s1[" << std::get<2>(res).first << ":" << std::get<2>(res).second << "], s2[" << std::get<3>(res).first << ":" << std::get<3>(res).second << "]" << std::endl;
             std::cout << "CIGAR string:" << std::endl;

--- a/wfa_lm.hpp
+++ b/wfa_lm.hpp
@@ -42,12 +42,6 @@
 
 namespace wfalm {
 
-// A few forward declarations (users can ignore these)
-class FwdCompareMatchFunc;
-class RevCompareMatchFunc;
-class StringView;
-class RevStringView;
-
 
 /*
  * Operation in a CIGAR string (as defined in SAM format specification)
@@ -428,14 +422,14 @@ protected:
     };
     
     // give the wrapper access to the dispatch function
-    friend class StandardGlobalWFA<FwdCompareMatchFunc, StringView>;
-    friend class StandardSemilocalWFA<RevCompareMatchFunc, RevStringView>;
-    friend class LowMemGlobalWFA<FwdCompareMatchFunc, StringView>;
-    friend class LowMemSemilocalWFA<RevCompareMatchFunc, RevStringView>;
-    friend class RecursiveGlobalWFA<FwdCompareMatchFunc, StringView>;
-    friend class RecursiveSemilocalWFA<RevCompareMatchFunc, RevStringView>;
-    friend class AdaptiveGlobalWFA<FwdCompareMatchFunc, StringView>;
-    friend class AdaptiveSemilocalWFA<RevCompareMatchFunc, RevStringView>;
+    template<class MatchFunc, class StringType> friend class StandardGlobalWFA;
+    template<class MatchFunc, class StringType> friend class StandardSemilocalWFA;
+    template<class MatchFunc, class StringType> friend class LowMemGlobalWFA;
+    template<class MatchFunc, class StringType> friend class LowMemSemilocalWFA;
+    template<class MatchFunc, class StringType> friend class RecursiveGlobalWFA;
+    template<class MatchFunc, class StringType> friend class RecursiveSemilocalWFA;
+    template<class MatchFunc, class StringType> friend class AdaptiveGlobalWFA;
+    template<class MatchFunc, class StringType> friend class AdaptiveSemilocalWFA;
     
     // central routine that back-ends the user-facing interface
     template<bool Local, int Mem, typename MatchFunc, typename StringType>

--- a/wfa_lm_st.hpp
+++ b/wfa_lm_st.hpp
@@ -161,13 +161,13 @@ public:
     ///     - a pair of indexes indicating the interval of aligned sequence on seq1
     ///     - a pair of indexes indicating the interval of aligned sequence on seq2
     inline std::tuple<std::vector<CIGAROp>, int32_t, std::pair<size_t, size_t>, std::pair<size_t, size_t>>
-    wavefront_align_local_recursive(const char* seq1, size_t len1,
-                                    const char* seq2, size_t len2,
-                                    uint64_t max_mem,
-                                    size_t anchor_begin_1, size_t anchor_end_1,
-                                    size_t anchor_begin_2, size_t anchor_end_2,
-                                    bool anchor_is_match = true) const;
-    
+    wavefront_align_local_adaptive(const char* seq1, size_t len1,
+                                   const char* seq2, size_t len2,
+                                   uint64_t max_mem,
+                                   size_t anchor_begin_1, size_t anchor_end_1,
+                                   size_t anchor_begin_2, size_t anchor_end_2,
+                                   bool anchor_is_match = true) const;
+
     /// Locally align two sequences from a seed using the recursive WFA as an
     /// alignment engine. *Can only called if WFAligner was initialized with
     /// Smith-Waterman-Gotoh scoring parameters in the constructor.*
@@ -196,7 +196,7 @@ public:
                                     size_t anchor_begin_1, size_t anchor_end_1,
                                     size_t anchor_begin_2, size_t anchor_end_2,
                                     bool anchor_is_match = true) const;
-    
+
     /// Locally align two sequences from a seed using the low memory WFA as an
     /// alignment engine. *Can only called if WFAligner was initialized with
     /// Smith-Waterman-Gotoh scoring parameters in the constructor.*
@@ -225,7 +225,7 @@ public:
                                   size_t anchor_begin_1, size_t anchor_end_1,
                                   size_t anchor_begin_2, size_t anchor_end_2,
                                   bool anchor_is_match = true) const;
-    
+
     /// Locally align two sequences from a seed using the standard WFA as an
     /// alignment engine. *Can only called if WFAligner was initialized with
     /// Smith-Waterman-Gotoh scoring parameters in the constructor.*
@@ -255,17 +255,15 @@ public:
                           size_t anchor_begin_2, size_t anchor_end_2,
                           bool anchor_is_match = true) const;
     
+};
     
     
     
     
-    
-    
-    
-    
+
     /*******************************************************************
      *******************************************************************
-     ***             Only internal functions below here              ***
+     ***             Only internal methods below here              ***
      *******************************************************************
      *******************************************************************/
     
@@ -277,111 +275,129 @@ public:
     
     
     
-private:
     
-    // configure the suffix tree we want
     
-    typedef sdsl::cst_sada<sdsl::csa_bitcompressed<>,
-                           sdsl::lcp_dac<1>,
-                           sdsl::bp_support_gg<sdsl::nearest_neighbour_dictionary<1>,
-                                               sdsl::rank_support_v<>,
-                                               sdsl::select_support_mcl<>, 64>,
-                           sdsl::rank_support_v<10, 2>,
-                           sdsl::select_support_mcl<10, 2>> SuffixTree;
+
+typedef sdsl::cst_sada<sdsl::csa_bitcompressed<>,
+                       sdsl::lcp_dac<1>,
+                       sdsl::bp_support_gg<sdsl::nearest_neighbour_dictionary<1>,
+                                           sdsl::rank_support_v<>,
+                                           sdsl::select_support_mcl<>, 64>,
+                       sdsl::rank_support_v<10, 2>,
+                       sdsl::select_support_mcl<10, 2>> SuffixTree;
+
+// a match computing function based on the suffix tree
+struct STMatchFunc {
+public:
+    STMatchFunc() = default;
+    ~STMatchFunc() = default;
     
-    // a match computing function based on the suffix tree
+protected:
+    
     template<typename StringType>
-    struct STMatchFunc {
+    void init(const StringType& seq1, const StringType& seq2) {
         
-        STMatchFunc(const StringType& seq1, const StringType& seq2) : offset(seq1.size() + 1) {
+        offset = seq1.size() + 1;
+        
+        // encoding:
+        //  a/A  1
+        //  c/C  2
+        //  g/G  3
+        //  t/T  4
+        //  else 5
+        //  $    6
+        static const uint8_t separator = 6;
+        static const uint8_t st_encode[256] {
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 0
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 32
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
             
-            // encoding:
-            //  a/A  1
-            //  c/C  2
-            //  g/G  3
-            //  t/T  4
-            //  else 5
-            //  $    6
-            static const uint8_t separator = 6;
-            static const uint8_t st_encode[256] {
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 0
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 32
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
-                
-                uint8_t(5), uint8_t(1), uint8_t(5), uint8_t(2), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(3),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 64
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(4), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
-                uint8_t(5), uint8_t(1), uint8_t(5), uint8_t(2), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(3),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 96
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(4), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
-                
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 128
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 160
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
-                
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 192
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 224
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
-                uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5)  //
-            };
+            uint8_t(5), uint8_t(1), uint8_t(5), uint8_t(2), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(3),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 64
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(4), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
+            uint8_t(5), uint8_t(1), uint8_t(5), uint8_t(2), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(3),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 96
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(4), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
             
-            // TODO: i wish this were possible with an implicit copy, but looks like probably not
-            // since the sdsl::store_to_file that backends the in-memory construction is only
-            // specialized for string and char*
-            //  - but also this gets us around the StringView vs. string issues in local alignment...
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 128
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 160
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
             
-            // encode the joined string and the sentinel in a 3-bit alphabet
-            std::string combined_seq(seq1.size() + seq2.size() + 1, 0);
-            size_t i;
-            for (i = 0; i < seq1.size(); ++i) {
-                combined_seq[i] = st_encode[seq1[i]];
-            }
-            combined_seq[i] = separator;
-            ++i;
-            for (size_t j = 0; j < seq2.size(); ++i, ++j) {
-                combined_seq[i] = st_encode[seq2[j]];
-            }
-            
-            // construct in memory with 1-byte words
-            sdsl::construct_im(suffix_tree, combined_seq, 1);
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 192
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), //
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), // 224
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5),
+            uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5), uint8_t(5)  //
+        };
+        
+        // TODO: i wish this were possible with an implicit copy, but looks like probably not
+        // since the sdsl::store_to_file that backends the in-memory construction is only
+        // specialized for string and char*
+        //  - but also this gets us around the StringView vs. string issues in local alignment...
+        
+        // encode the joined string and the sentinel in a 3-bit alphabet
+        std::string combined_seq(seq1.size() + seq2.size() + 1, 0);
+        size_t i;
+        for (i = 0; i < seq1.size(); ++i) {
+            combined_seq[i] = st_encode[seq1[i]];
+        }
+        combined_seq[i] = separator;
+        ++i;
+        for (size_t j = 0; j < seq2.size(); ++i, ++j) {
+            combined_seq[i] = st_encode[seq2[j]];
         }
         
-        inline size_t operator()(size_t i, size_t j) const {
-            // in sdsl, suffix array indexes are 0-based, but leaf ranks are 1-based
-            return suffix_tree.depth(suffix_tree.lca(suffix_tree.select_leaf(suffix_tree.csa.isa[i] + 1),
-                                                     suffix_tree.select_leaf(suffix_tree.csa.isa[offset + j] + 1)));
-        }
-        
-        SuffixTree suffix_tree;
-        size_t offset;
-    };
+        // construct in memory with 1-byte words
+        sdsl::construct_im(suffix_tree, combined_seq, 1);
+    }
     
-    // give the wrapper access to the dispatch function
-    friend class WFAligner<NumPW>::StandardGlobalWFA<STMatchFunc<StringView>, StringView>;
-    friend class WFAligner<NumPW>::StandardSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>;
-    friend class WFAligner<NumPW>::LowMemGlobalWFA<STMatchFunc<StringView>, StringView>;
-    friend class WFAligner<NumPW>::LowMemSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>;
-    friend class WFAligner<NumPW>::RecursiveGlobalWFA<STMatchFunc<StringView>, StringView>;
-    friend class WFAligner<NumPW>::RecursiveSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>;
-    friend class WFAligner<NumPW>::AdaptiveGlobalWFA<STMatchFunc<StringView>, StringView>;
-    friend class WFAligner<NumPW>::AdaptiveSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>;
+    inline size_t lce(size_t i, size_t j) const {
+        // in sdsl, suffix array indexes are 0-based, but leaf ranks are 1-based
+        return suffix_tree.depth(suffix_tree.lca(suffix_tree.select_leaf(suffix_tree.csa.isa[i] + 1),
+                                                 suffix_tree.select_leaf(suffix_tree.csa.isa[offset + j] + 1)));
+    }
     
+    SuffixTree suffix_tree;
+    size_t offset;
+};
+
+class FwdSTMatchFunc : STMatchFunc {
+public:
+    
+    FwdSTMatchFunc(const StringView& seq1, const StringView& seq2) {
+        init<StringView>(seq1, seq2);
+    }
+    
+    inline size_t operator()(size_t i, size_t j) const {
+        return lce(i, j);
+    }
+};
+
+class RevSTMatchFunc : STMatchFunc {
+public:
+    
+    RevSTMatchFunc(const RevStringView& seq1, const RevStringView& seq2) {
+        init<RevStringView>(seq1, seq2);
+    }
+    
+    inline size_t operator()(size_t i, size_t j) const {
+        return lce(i, j);
+    }
 };
 
 template<int NumPW>
@@ -407,7 +423,7 @@ WFAlignerST<NumPW>::wavefront_align(const char* seq1, size_t len1,
                              const char* seq2, size_t len2) const {
     StringView str1(seq1, 0, len1);
     StringView str2(seq2, 0, len2);
-    return WFAligner<NumPW>::template wavefront_dispatch<false, WFAligner<NumPW>::StdMem, STMatchFunc<StringView>>(str1, str2,
+    return WFAligner<NumPW>::template wavefront_dispatch<false, WFAligner<NumPW>::StdMem, FwdSTMatchFunc>(str1, str2,
                                                                       std::numeric_limits<uint64_t>::max());
 }
 
@@ -417,7 +433,7 @@ WFAlignerST<NumPW>::wavefront_align_low_mem(const char* seq1, size_t len1,
                                    const char* seq2, size_t len2) const {
     StringView str1(seq1, 0, len1);
     StringView str2(seq2, 0, len2);
-    return WFAligner<NumPW>::template wavefront_dispatch<false, WFAligner<NumPW>::LowMem, STMatchFunc<StringView>>(str1, str2,
+    return WFAligner<NumPW>::template wavefront_dispatch<false, WFAligner<NumPW>::LowMem, FwdSTMatchFunc>(str1, str2,
                                                                       std::numeric_limits<uint64_t>::max());
 }
 
@@ -427,7 +443,7 @@ WFAlignerST<NumPW>::wavefront_align_recursive(const char* seq1, size_t len1,
                                      const char* seq2, size_t len2) const {
     StringView str1(seq1, 0, len1);
     StringView str2(seq2, 0, len2);
-    return WFAligner<NumPW>::template wavefront_dispatch<false, WFAligner<NumPW>::Recursive, STMatchFunc<StringView>>(str1, str2,
+    return WFAligner<NumPW>::template wavefront_dispatch<false, WFAligner<NumPW>::Recursive, FwdSTMatchFunc>(str1, str2,
                                                                          std::numeric_limits<uint64_t>::max());
 }
 
@@ -438,7 +454,7 @@ WFAlignerST<NumPW>::wavefront_align_adaptive(const char* seq1, size_t len1,
                                       uint64_t max_mem) const {
     StringView str1(seq1, 0, len1);
     StringView str2(seq2, 0, len2);
-    return WFAligner<NumPW>::template wavefront_dispatch<false, WFAligner<NumPW>::AdaptiveMem, STMatchFunc<StringView>>(str1, str2, max_mem);
+    return WFAligner<NumPW>::template wavefront_dispatch<false, WFAligner<NumPW>::AdaptiveMem, FwdSTMatchFunc>(str1, str2, max_mem);
 }
 
 template<int NumPW>
@@ -448,15 +464,17 @@ WFAlignerST<NumPW>::wavefront_align_local(const char* seq1, size_t len1,
                                  size_t anchor_begin_1, size_t anchor_end_1,
                                  size_t anchor_begin_2, size_t anchor_end_2,
                                  bool anchor_is_match) const {
-    
+
     // configure the alignment and match functions
-    
-    return WFAligner<NumPW>::template wavefront_align_local_core<
-            WFAligner<NumPW>::template StandardSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>,
-            WFAligner<NumPW>::template StandardGlobalWFA<STMatchFunc<StringView>, StringView>,
-            WFAligner<NumPW>::template StandardSemilocalWFA<STMatchFunc<StringView>, StringView>>
-        (seq1, len1, seq2, len2, std::numeric_limits<uint64_t>::max(),
-         anchor_begin_1, anchor_end_1, anchor_begin_2, anchor_end_2, anchor_is_match);
+    typedef typename WFAligner<NumPW>::template StandardSemilocalWFA<RevSTMatchFunc, RevStringView> PrefWFA;
+    typedef typename WFAligner<NumPW>::template StandardGlobalWFA<FwdSTMatchFunc, StringView> AnchorWFA;
+    typedef typename WFAligner<NumPW>::template StandardSemilocalWFA<FwdSTMatchFunc, StringView> SuffWFA;
+
+    return WFAligner<NumPW>::template wavefront_align_local_core<PrefWFA, AnchorWFA, SuffWFA>(seq1, len1, seq2, len2,
+                                                                                              std::numeric_limits<uint64_t>::max(),
+                                                                                              anchor_begin_1, anchor_end_1,
+                                                                                              anchor_begin_2, anchor_end_2,
+                                                                                              anchor_is_match);
 }
 
 template<int NumPW>
@@ -466,15 +484,17 @@ WFAlignerST<NumPW>::wavefront_align_local_low_mem(const char* seq1, size_t len1,
                                          size_t anchor_begin_1, size_t anchor_end_1,
                                          size_t anchor_begin_2, size_t anchor_end_2,
                                          bool anchor_is_match) const {
-    
+
     // configure the alignment and match functions
-    
-    return WFAligner<NumPW>::template wavefront_align_local_core<
-            WFAligner<NumPW>::template LowMemSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>,
-            WFAligner<NumPW>::template LowMemGlobalWFA<STMatchFunc<StringView>, StringView>,
-            WFAligner<NumPW>::template LowMemSemilocalWFA<STMatchFunc<StringView>, StringView>>
-        (seq1, len1, seq2, len2, std::numeric_limits<uint64_t>::max(),
-         anchor_begin_1, anchor_end_1, anchor_begin_2, anchor_end_2, anchor_is_match);
+    typedef typename WFAligner<NumPW>::template LowMemSemilocalWFA<RevSTMatchFunc, RevStringView> PrefWFA;
+    typedef typename WFAligner<NumPW>::template LowMemGlobalWFA<FwdSTMatchFunc, StringView> AnchorWFA;
+    typedef typename WFAligner<NumPW>::template LowMemSemilocalWFA<FwdSTMatchFunc, StringView> SuffWFA;
+
+    return WFAligner<NumPW>::template wavefront_align_local_core<PrefWFA, AnchorWFA, SuffWFA>(seq1, len1, seq2, len2,
+                                                                                              std::numeric_limits<uint64_t>::max(),
+                                                                                              anchor_begin_1, anchor_end_1,
+                                                                                              anchor_begin_2, anchor_end_2,
+                                                                                              anchor_is_match);
 }
 
 template<int NumPW>
@@ -484,36 +504,39 @@ WFAlignerST<NumPW>::wavefront_align_local_recursive(const char* seq1, size_t len
                                              size_t anchor_begin_1, size_t anchor_end_1,
                                              size_t anchor_begin_2, size_t anchor_end_2,
                                              bool anchor_is_match) const {
-    
+
     // configure the alignment and match functions
-    
-    return WFAligner<NumPW>::template wavefront_align_local_core<
-            WFAligner<NumPW>::template RecursiveSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>,
-            WFAligner<NumPW>::template RecursiveGlobalWFA<STMatchFunc<StringView>, StringView>,
-            WFAligner<NumPW>::template RecursiveSemilocalWFA<STMatchFunc<StringView>, StringView>>
-        (seq1, len1, seq2, len2, std::numeric_limits<uint64_t>::max(),
-         anchor_begin_1, anchor_end_1, anchor_begin_2, anchor_end_2, anchor_is_match);
+    typedef typename WFAligner<NumPW>::template RecursiveSemilocalWFA<RevSTMatchFunc, RevStringView> PrefWFA;
+    typedef typename WFAligner<NumPW>::template RecursiveGlobalWFA<FwdSTMatchFunc, StringView> AnchorWFA;
+    typedef typename WFAligner<NumPW>::template RecursiveSemilocalWFA<FwdSTMatchFunc, StringView> SuffWFA;
+
+    return WFAligner<NumPW>::template wavefront_align_local_core<PrefWFA, AnchorWFA, SuffWFA>(seq1, len1, seq2, len2,
+                                                                                              std::numeric_limits<uint64_t>::max(),
+                                                                                              anchor_begin_1, anchor_end_1,
+                                                                                              anchor_begin_2, anchor_end_2,
+                                                                                              anchor_is_match);
 
 }
 
 template<int NumPW>
 inline std::tuple<std::vector<CIGAROp>, int32_t, std::pair<size_t, size_t>, std::pair<size_t, size_t>>
-WFAlignerST<NumPW>::wavefront_align_local_recursive(const char* seq1, size_t len1,
+WFAlignerST<NumPW>::wavefront_align_local_adaptive(const char* seq1, size_t len1,
                                              const char* seq2, size_t len2,
                                              uint64_t max_mem,
                                              size_t anchor_begin_1, size_t anchor_end_1,
                                              size_t anchor_begin_2, size_t anchor_end_2,
                                              bool anchor_is_match) const {
-    
+
     // configure the alignment and match functions
+    typedef typename WFAligner<NumPW>::template AdaptiveSemilocalWFA<RevSTMatchFunc, RevStringView> PrefWFA;
+    typedef typename WFAligner<NumPW>::template AdaptiveGlobalWFA<FwdSTMatchFunc, StringView> AnchorWFA;
+    typedef typename WFAligner<NumPW>::template AdaptiveSemilocalWFA<FwdSTMatchFunc, StringView> SuffWFA;
     
-    return WFAligner<NumPW>::template wavefront_align_local_core<
-            WFAligner<NumPW>::template RecursiveSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>,
-            WFAligner<NumPW>::template RecursiveGlobalWFA<STMatchFunc<StringView>, StringView>,
-            WFAligner<NumPW>::template RecursiveSemilocalWFA<STMatchFunc<StringView>, StringView>>
-        (seq1, len1, seq2, len2, max_mem,
-         anchor_begin_1, anchor_end_1, anchor_begin_2, anchor_end_2, anchor_is_match);
-    
+    return WFAligner<NumPW>::template wavefront_align_local_core<PrefWFA, AnchorWFA, SuffWFA>(seq1, len1, seq2, len2, max_mem,
+                                                                                              anchor_begin_1, anchor_end_1,
+                                                                                              anchor_begin_2, anchor_end_2,
+                                                                                              anchor_is_match);
+
 }
 
 } // end namespace wfalm

--- a/wfa_lm_st.hpp
+++ b/wfa_lm_st.hpp
@@ -42,7 +42,8 @@ namespace wfalm {
  * algorithm based on a suffix tree to compute matches. In most cases, this is
  * slower than the default comparison-based match computation.
  */
-class WFAlignerST : public WFAligner {
+template<int NumPW>
+class WFAlignerST : public WFAligner<NumPW> {
     
 public:
     
@@ -67,7 +68,7 @@ public:
     /// behind the furthest-reaching diagonal. This can lead to suboptimal alignments,
     /// but it also can increase speed and reduce memory use. If set to a number < 0,
     /// no pruning is performed.
-    using WFAligner::lagging_diagonal_prune;
+    using WFAligner<NumPW>::lagging_diagonal_prune;
     
     /***********************
      *  Alignment methods  *
@@ -372,131 +373,132 @@ private:
     };
     
     // give the wrapper access to the dispatch function
-    friend class StandardGlobalWFA<STMatchFunc<StringView>, StringView>;
-    friend class StandardSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>;
-    friend class LowMemGlobalWFA<STMatchFunc<StringView>, StringView>;
-    friend class LowMemSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>;
-    friend class RecursiveGlobalWFA<STMatchFunc<StringView>, StringView>;
-    friend class RecursiveSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>;
-    friend class AdaptiveGlobalWFA<STMatchFunc<StringView>, StringView>;
-    friend class AdaptiveSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>;
+    friend class WFAligner<NumPW>::StandardGlobalWFA<STMatchFunc<StringView>, StringView>;
+    friend class WFAligner<NumPW>::StandardSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>;
+    friend class WFAligner<NumPW>::LowMemGlobalWFA<STMatchFunc<StringView>, StringView>;
+    friend class WFAligner<NumPW>::LowMemSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>;
+    friend class WFAligner<NumPW>::RecursiveGlobalWFA<STMatchFunc<StringView>, StringView>;
+    friend class WFAligner<NumPW>::RecursiveSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>;
+    friend class WFAligner<NumPW>::AdaptiveGlobalWFA<STMatchFunc<StringView>, StringView>;
+    friend class WFAligner<NumPW>::AdaptiveSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>;
     
 };
 
-WFAlignerST::WFAlignerST() : WFAligner() {}
+template<int NumPW>
+WFAlignerST<NumPW>::WFAlignerST() : WFAligner<NumPW>() {}
 
-WFAlignerST::WFAlignerST(uint32_t mismatch, uint32_t gap_open, uint32_t gap_extend)
-    : WFAligner(mismatch, gap_open, gap_extend)
+template<int NumPW>
+WFAlignerST<NumPW>::WFAlignerST(uint32_t mismatch, uint32_t gap_open, uint32_t gap_extend)
+    : WFAligner<NumPW>(mismatch, gap_open, gap_extend)
 {
     // only need to delegate to WFAligner
 }
 
-WFAlignerST::WFAlignerST(uint32_t match, uint32_t mismatch, uint32_t gap_open, uint32_t gap_extend)
-    : WFAligner(match, mismatch, gap_open, gap_extend)
+template<int NumPW>
+WFAlignerST<NumPW>::WFAlignerST(uint32_t match, uint32_t mismatch, uint32_t gap_open, uint32_t gap_extend)
+    : WFAligner<NumPW>(match, mismatch, gap_open, gap_extend)
 {
     // only need to delegate to WFAligner
 }
 
+template<int NumPW>
 inline std::pair<std::vector<CIGAROp>, int32_t>
-WFAlignerST::wavefront_align(const char* seq1, size_t len1,
+WFAlignerST<NumPW>::wavefront_align(const char* seq1, size_t len1,
                              const char* seq2, size_t len2) const {
     StringView str1(seq1, 0, len1);
     StringView str2(seq2, 0, len2);
-    return wavefront_dispatch<false, StdMem, STMatchFunc<StringView>>(str1, str2,
+    return WFAligner<NumPW>::template wavefront_dispatch<false, WFAligner<NumPW>::StdMem, STMatchFunc<StringView>>(str1, str2,
                                                                       std::numeric_limits<uint64_t>::max());
 }
 
-
+template<int NumPW>
 inline std::pair<std::vector<CIGAROp>, int32_t>
-WFAlignerST::wavefront_align_low_mem(const char* seq1, size_t len1,
+WFAlignerST<NumPW>::wavefront_align_low_mem(const char* seq1, size_t len1,
                                    const char* seq2, size_t len2) const {
     StringView str1(seq1, 0, len1);
     StringView str2(seq2, 0, len2);
-    return wavefront_dispatch<false, LowMem, STMatchFunc<StringView>>(str1, str2,
+    return WFAligner<NumPW>::template wavefront_dispatch<false, WFAligner<NumPW>::LowMem, STMatchFunc<StringView>>(str1, str2,
                                                                       std::numeric_limits<uint64_t>::max());
 }
 
-
+template<int NumPW>
 inline std::pair<std::vector<CIGAROp>, int32_t>
-WFAlignerST::wavefront_align_recursive(const char* seq1, size_t len1,
+WFAlignerST<NumPW>::wavefront_align_recursive(const char* seq1, size_t len1,
                                      const char* seq2, size_t len2) const {
     StringView str1(seq1, 0, len1);
     StringView str2(seq2, 0, len2);
-    return wavefront_dispatch<false, Recursive, STMatchFunc<StringView>>(str1, str2,
+    return WFAligner<NumPW>::template wavefront_dispatch<false, WFAligner<NumPW>::Recursive, STMatchFunc<StringView>>(str1, str2,
                                                                          std::numeric_limits<uint64_t>::max());
 }
 
-
-
+template<int NumPW>
 inline std::pair<std::vector<CIGAROp>, int32_t>
-WFAlignerST::wavefront_align_adaptive(const char* seq1, size_t len1,
+WFAlignerST<NumPW>::wavefront_align_adaptive(const char* seq1, size_t len1,
                                       const char* seq2, size_t len2,
                                       uint64_t max_mem) const {
     StringView str1(seq1, 0, len1);
     StringView str2(seq2, 0, len2);
-    return wavefront_dispatch<false, AdaptiveMem, STMatchFunc<StringView>>(str1, str2, max_mem);
+    return WFAligner<NumPW>::template wavefront_dispatch<false, WFAligner<NumPW>::AdaptiveMem, STMatchFunc<StringView>>(str1, str2, max_mem);
 }
 
+template<int NumPW>
 inline std::tuple<std::vector<CIGAROp>, int32_t, std::pair<size_t, size_t>, std::pair<size_t, size_t>>
-WFAlignerST::wavefront_align_local(const char* seq1, size_t len1,
+WFAlignerST<NumPW>::wavefront_align_local(const char* seq1, size_t len1,
                                  const char* seq2, size_t len2,
                                  size_t anchor_begin_1, size_t anchor_end_1,
                                  size_t anchor_begin_2, size_t anchor_end_2,
                                  bool anchor_is_match) const {
     
     // configure the alignment and match functions
-    typedef StandardSemilocalWFA<STMatchFunc<RevStringView>, RevStringView> PrefWFA;
-    typedef StandardGlobalWFA<STMatchFunc<StringView>, StringView> AnchorWFA;
-    typedef StandardSemilocalWFA<STMatchFunc<StringView>, StringView> SuffWFA;
     
-    return wavefront_align_local_core<PrefWFA, AnchorWFA, SuffWFA>(seq1, len1, seq2, len2,
-                                                                   std::numeric_limits<uint64_t>::max(),
-                                                                   anchor_begin_1, anchor_end_1,
-                                                                   anchor_begin_2, anchor_end_2,
-                                                                   anchor_is_match);
+    return WFAligner<NumPW>::template wavefront_align_local_core<
+            WFAligner<NumPW>::template StandardSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>,
+            WFAligner<NumPW>::template StandardGlobalWFA<STMatchFunc<StringView>, StringView>,
+            WFAligner<NumPW>::template StandardSemilocalWFA<STMatchFunc<StringView>, StringView>>
+        (seq1, len1, seq2, len2, std::numeric_limits<uint64_t>::max(),
+         anchor_begin_1, anchor_end_1, anchor_begin_2, anchor_end_2, anchor_is_match);
 }
 
+template<int NumPW>
 inline std::tuple<std::vector<CIGAROp>, int32_t, std::pair<size_t, size_t>, std::pair<size_t, size_t>>
-WFAlignerST::wavefront_align_local_low_mem(const char* seq1, size_t len1,
+WFAlignerST<NumPW>::wavefront_align_local_low_mem(const char* seq1, size_t len1,
                                          const char* seq2, size_t len2,
                                          size_t anchor_begin_1, size_t anchor_end_1,
                                          size_t anchor_begin_2, size_t anchor_end_2,
                                          bool anchor_is_match) const {
     
     // configure the alignment and match functions
-    typedef LowMemSemilocalWFA<STMatchFunc<RevStringView>, RevStringView> PrefWFA;
-    typedef LowMemGlobalWFA<STMatchFunc<StringView>, StringView> AnchorWFA;
-    typedef LowMemSemilocalWFA<STMatchFunc<StringView>, StringView> SuffWFA;
     
-    return wavefront_align_local_core<PrefWFA, AnchorWFA, SuffWFA>(seq1, len1, seq2, len2,
-                                                                   std::numeric_limits<uint64_t>::max(),
-                                                                   anchor_begin_1, anchor_end_1,
-                                                                   anchor_begin_2, anchor_end_2,
-                                                                   anchor_is_match);
+    return WFAligner<NumPW>::template wavefront_align_local_core<
+            WFAligner<NumPW>::template LowMemSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>,
+            WFAligner<NumPW>::template LowMemGlobalWFA<STMatchFunc<StringView>, StringView>,
+            WFAligner<NumPW>::template LowMemSemilocalWFA<STMatchFunc<StringView>, StringView>>
+        (seq1, len1, seq2, len2, std::numeric_limits<uint64_t>::max(),
+         anchor_begin_1, anchor_end_1, anchor_begin_2, anchor_end_2, anchor_is_match);
 }
 
+template<int NumPW>
 inline std::tuple<std::vector<CIGAROp>, int32_t, std::pair<size_t, size_t>, std::pair<size_t, size_t>>
-WFAlignerST::wavefront_align_local_recursive(const char* seq1, size_t len1,
+WFAlignerST<NumPW>::wavefront_align_local_recursive(const char* seq1, size_t len1,
                                              const char* seq2, size_t len2,
                                              size_t anchor_begin_1, size_t anchor_end_1,
                                              size_t anchor_begin_2, size_t anchor_end_2,
                                              bool anchor_is_match) const {
     
     // configure the alignment and match functions
-    typedef RecursiveSemilocalWFA<STMatchFunc<RevStringView>, RevStringView> PrefWFA;
-    typedef RecursiveGlobalWFA<STMatchFunc<StringView>, StringView> AnchorWFA;
-    typedef RecursiveSemilocalWFA<STMatchFunc<StringView>, StringView> SuffWFA;
     
-    return wavefront_align_local_core<PrefWFA, AnchorWFA, SuffWFA>(seq1, len1, seq2, len2,
-                                                                   std::numeric_limits<uint64_t>::max(),
-                                                                   anchor_begin_1, anchor_end_1,
-                                                                   anchor_begin_2, anchor_end_2,
-                                                                   anchor_is_match);
+    return WFAligner<NumPW>::template wavefront_align_local_core<
+            WFAligner<NumPW>::template RecursiveSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>,
+            WFAligner<NumPW>::template RecursiveGlobalWFA<STMatchFunc<StringView>, StringView>,
+            WFAligner<NumPW>::template RecursiveSemilocalWFA<STMatchFunc<StringView>, StringView>>
+        (seq1, len1, seq2, len2, std::numeric_limits<uint64_t>::max(),
+         anchor_begin_1, anchor_end_1, anchor_begin_2, anchor_end_2, anchor_is_match);
 
 }
 
+template<int NumPW>
 inline std::tuple<std::vector<CIGAROp>, int32_t, std::pair<size_t, size_t>, std::pair<size_t, size_t>>
-WFAlignerST::wavefront_align_local_recursive(const char* seq1, size_t len1,
+WFAlignerST<NumPW>::wavefront_align_local_recursive(const char* seq1, size_t len1,
                                              const char* seq2, size_t len2,
                                              uint64_t max_mem,
                                              size_t anchor_begin_1, size_t anchor_end_1,
@@ -504,14 +506,13 @@ WFAlignerST::wavefront_align_local_recursive(const char* seq1, size_t len1,
                                              bool anchor_is_match) const {
     
     // configure the alignment and match functions
-    typedef RecursiveSemilocalWFA<STMatchFunc<RevStringView>, RevStringView> PrefWFA;
-    typedef RecursiveGlobalWFA<STMatchFunc<StringView>, StringView> AnchorWFA;
-    typedef RecursiveSemilocalWFA<STMatchFunc<StringView>, StringView> SuffWFA;
     
-    return wavefront_align_local_core<PrefWFA, AnchorWFA, SuffWFA>(seq1, len1, seq2, len2, max_mem,
-                                                                   anchor_begin_1, anchor_end_1,
-                                                                   anchor_begin_2, anchor_end_2,
-                                                                   anchor_is_match);
+    return WFAligner<NumPW>::template wavefront_align_local_core<
+            WFAligner<NumPW>::template RecursiveSemilocalWFA<STMatchFunc<RevStringView>, RevStringView>,
+            WFAligner<NumPW>::template RecursiveGlobalWFA<STMatchFunc<StringView>, StringView>,
+            WFAligner<NumPW>::template RecursiveSemilocalWFA<STMatchFunc<StringView>, StringView>>
+        (seq1, len1, seq2, len2, max_mem,
+         anchor_begin_1, anchor_end_1, anchor_begin_2, anchor_end_2, anchor_is_match);
     
 }
 

--- a/wfa_lm_st.hpp
+++ b/wfa_lm_st.hpp
@@ -50,12 +50,16 @@ public:
     /// Initialize with WFA-style score parameters. On opening an insertion or
     /// deletion, *both* the gap open and gap extend penalties are applied.
     /// Scores returned by alignment methods will also be WFA-style.
-    WFAlignerST(uint32_t mismatch, uint32_t gap_open, uint32_t gap_extend);
+    WFAlignerST(uint32_t mismatch,
+                std::array<uint32_t, std::max(1, NumPW)> gap_extend,
+                std::array<uint32_t, NumPW> gap_open);
     
     /// Initialize with Smith-Waterman-Gotoh-style score parameters. On opening an
     /// insertion or deletion, *both* the gap open and gap extend penalties are applied.
     /// Scores returned by alignment methods will also be Smith-Waterman-Gotoh-style.
-    WFAlignerST(uint32_t match, uint32_t mismatch, uint32_t gap_open, uint32_t gap_extend);
+    WFAlignerST(uint32_t match, uint32_t mismatch,
+                std::array<uint32_t, std::max(1, NumPW)> gap_extend,
+                std::array<uint32_t, NumPW> gap_open);
     
     /// Default constructor. Performs edit distance alignment.
     WFAlignerST();
@@ -404,15 +408,19 @@ template<int NumPW>
 WFAlignerST<NumPW>::WFAlignerST() : WFAligner<NumPW>() {}
 
 template<int NumPW>
-WFAlignerST<NumPW>::WFAlignerST(uint32_t mismatch, uint32_t gap_open, uint32_t gap_extend)
-    : WFAligner<NumPW>(mismatch, gap_open, gap_extend)
+WFAlignerST<NumPW>::WFAlignerST(uint32_t mismatch,
+                                std::array<uint32_t, std::max(1, NumPW)> gap_extend,
+                                std::array<uint32_t, NumPW> gap_open)
+    : WFAligner<NumPW>(mismatch, gap_extend, gap_open)
 {
     // only need to delegate to WFAligner
 }
 
 template<int NumPW>
-WFAlignerST<NumPW>::WFAlignerST(uint32_t match, uint32_t mismatch, uint32_t gap_open, uint32_t gap_extend)
-    : WFAligner<NumPW>(match, mismatch, gap_open, gap_extend)
+WFAlignerST<NumPW>::WFAlignerST(uint32_t match, uint32_t mismatch,
+                                std::array<uint32_t, std::max(1, NumPW)> gap_extend,
+                                std::array<uint32_t, NumPW> gap_open)
+    : WFAligner<NumPW>(match, mismatch, gap_extend, gap_open)
 {
     // only need to delegate to WFAligner
 }


### PR DESCRIPTION
The implementation is based on a template parameter, and thus it can be used to designate any number of piecewise segments.